### PR TITLE
Add modular Minecraft Discord bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+venv/
+config.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# DiscordMcBot
-Discord Botum
+# Minecraft Discord Botu
+
+Minecraft topluluğunuz için hazırlanmış, premium botların özelliklerini ücretsiz sağlayan bir açık kaynak bot.
+
+## Kurulum
+
+1. `python -m venv venv && source venv/bin/activate`
+2. `pip install -r requirements.txt`
+3. `python run_setup.py` komutuyla interaktif kurulum ekranından token, prefix vb. girin.
+4. `python bot.py` ile botu başlatın.
+
+## Özellikler
+- Moderasyon: Ban, kick, mute, temizleme.
+- Seviye sistemi: Mesaj aktivitesine göre XP/rol.
+- Ekonomi: Sanal para, mağaza, günlük ödül.
+- Müzik: YouTube’dan şarkı çalma.
+- Minecraft entegrasyonu: Sunucu durumu, oyuncu sayısı vb.
+
+## Komutlar
+Komutlar hem slash (`/komut`) hem de metin prefix'i (`!komut`) ile çalışır.
+
+| Komut | Açıklama |
+|-------|----------|
+| `kick <üye> [sebep]` | Bir üyeyi sunucudan atar. |
+| `ban <üye> [sebep]` | Bir üyeyi sunucudan yasaklar. |
+| `temizle <miktar>` | Kanalda belirtilen sayıda mesajı siler. |
+| `balance` | Mevcut bakiye bilgisini gösterir. |
+| `daily` | Günlük 100 coin ödülü alır. |
+| `level [üye]` | Belirtilen üyenin (veya komutu yazanın) seviyesini gösterir. |
+| `play <url>` | YouTube bağlantısından müzik çalar. |
+| `stop` | Ses kanalındaki çalmayı durdurur. |
+| `mcstatus <adres>` | Minecraft sunucusunun durumunu kontrol eder. |

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Komutlar hem slash (`/komut`) hem de metin prefix'i (`!komut`) ile çalışır.
 | `play <url>` | YouTube bağlantısından müzik çalar. |
 | `stop` | Ses kanalındaki çalmayı durdurur. |
 | `mcstatus <adres>` | Minecraft sunucusunun durumunu kontrol eder. |
+| `setup <welcome> <log> <level_up>` | Sunucu için karşılama, log ve seviye kanallarını ayarlar. |

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,8 @@ initial_extensions = [
     "cogs.economy",
     "cogs.levels",
     "cogs.music",
-    "cogs.minecraft"
+    "cogs.minecraft",
+    "cogs.setup",
 ]
 
 @bot.event

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,36 @@
+import json
+import asyncio
+import discord
+from discord.ext import commands
+
+with open("config.json", encoding="utf-8") as f:
+    config = json.load(f)
+
+intents = discord.Intents.all()
+bot = commands.Bot(command_prefix=config["prefix"], intents=intents)
+
+initial_extensions = [
+    "cogs.moderation",
+    "cogs.economy",
+    "cogs.levels",
+    "cogs.music",
+    "cogs.minecraft"
+]
+
+@bot.event
+async def on_ready():
+    print(f"{bot.user} olarak giriş yapıldı.")
+
+async def load_extensions():
+    for ext in initial_extensions:
+        await bot.load_extension(ext)
+    # Slash (application) commands need to be synced once
+    await bot.tree.sync()
+
+async def main():
+    async with bot:
+        await load_extensions()
+        await bot.start(config["token"])
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -1,0 +1,1 @@
+# Cog paketini tanıtır.

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1,0 +1,23 @@
+from discord.ext import commands
+
+class Economy(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.balances = {}
+
+    @commands.hybrid_command()
+    async def balance(self, ctx):
+        await ctx.defer()
+        bal = self.balances.get(ctx.author.id, 0)
+        await ctx.send(f"{ctx.author.mention}, bakiyen: {bal} coin.")
+
+    @commands.hybrid_command()
+    async def daily(self, ctx):
+        await ctx.defer()
+        bal = self.balances.get(ctx.author.id, 0)
+        bal += 100
+        self.balances[ctx.author.id] = bal
+        await ctx.send(f"Günlük ödül: 100 coin. Yeni bakiyen: {bal} coin.")
+
+async def setup(bot):
+    await bot.add_cog(Economy(bot))

--- a/cogs/levels.py
+++ b/cogs/levels.py
@@ -1,0 +1,25 @@
+import discord
+from discord.ext import commands
+
+class Levels(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.xp = {}
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author.bot:
+            return
+        self.xp[message.author.id] = self.xp.get(message.author.id, 0) + 10
+        await self.bot.process_commands(message)
+
+    @commands.hybrid_command()
+    async def level(self, ctx, member: discord.Member | None = None):
+        await ctx.defer()
+        member = member or ctx.author
+        xp = self.xp.get(member.id, 0)
+        lvl = xp // 100
+        await ctx.send(f"{member.mention} seviye {lvl}, XP {xp}.")
+
+async def setup(bot):
+    await bot.add_cog(Levels(bot))

--- a/cogs/minecraft.py
+++ b/cogs/minecraft.py
@@ -1,0 +1,23 @@
+import aiohttp
+from discord.ext import commands
+
+API = "https://api.mcsrvstat.us/2"
+
+class Minecraft(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.hybrid_command()
+    async def mcstatus(self, ctx, address: str):
+        await ctx.defer()
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{API}/{address}") as resp:
+                data = await resp.json()
+        if data.get("online"):
+            players = data.get("players", {}).get("online", 0)
+            await ctx.send(f"Sunucu aktif! Online oyuncu sayısı: {players}")
+        else:
+            await ctx.send("Sunucu kapalı ya da ulaşılamıyor.")
+
+async def setup(bot):
+    await bot.add_cog(Minecraft(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1,0 +1,30 @@
+import discord
+from discord.ext import commands
+
+class Moderation(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.hybrid_command()
+    @commands.has_permissions(kick_members=True)
+    async def kick(self, ctx, member: discord.Member, *, reason: str | None = None):
+        await ctx.defer()
+        await member.kick(reason=reason)
+        await ctx.send(f"{member} sunucudan atıldı.")
+
+    @commands.hybrid_command()
+    @commands.has_permissions(ban_members=True)
+    async def ban(self, ctx, member: discord.Member, *, reason: str | None = None):
+        await ctx.defer()
+        await member.ban(reason=reason)
+        await ctx.send(f"{member} sunucudan yasaklandı.")
+
+    @commands.hybrid_command(name="temizle")
+    @commands.has_permissions(manage_messages=True)
+    async def temizle(self, ctx, amount: int):
+        await ctx.defer()
+        await ctx.channel.purge(limit=amount + 1)
+        await ctx.send(f"{amount} mesaj silindi.", delete_after=5)
+
+async def setup(bot):
+    await bot.add_cog(Moderation(bot))

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -1,0 +1,30 @@
+import discord
+from discord.ext import commands
+import youtube_dl
+
+ytdl = youtube_dl.YoutubeDL({"format": "bestaudio", "quiet": True})
+
+class Music(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.hybrid_command()
+    async def play(self, ctx, url: str):
+        await ctx.defer()
+        vc = ctx.voice_client or await ctx.author.voice.channel.connect()
+        data = ytdl.extract_info(url, download=False)
+        source = await discord.FFmpegOpusAudio.from_probe(data["url"])
+        vc.play(source, after=lambda e: print("Çalma tamamlandı."))
+        await ctx.send("Çalma başladı.")
+
+    @commands.hybrid_command()
+    async def stop(self, ctx):
+        await ctx.defer()
+        if ctx.voice_client:
+            await ctx.voice_client.disconnect()
+            await ctx.send("Ses bağlantısı sonlandırıldı.")
+        else:
+            await ctx.send("Herhangi bir ses kanalında değilim.")
+
+async def setup(bot):
+    await bot.add_cog(Music(bot))

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+
+CONFIG_PATH = Path("config.json")
+
+
+class Setup(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.config = self._load_config()
+
+    def _load_config(self) -> dict:
+        if CONFIG_PATH.exists():
+            with CONFIG_PATH.open(encoding="utf-8") as f:
+                return json.load(f)
+        return {}
+
+    def _save_config(self) -> None:
+        with CONFIG_PATH.open("w", encoding="utf-8") as f:
+            json.dump(self.config, f, indent=2)
+
+    @commands.hybrid_command()
+    @commands.has_permissions(administrator=True)
+    async def setup(
+        self,
+        ctx: commands.Context,
+        welcome_channel: discord.TextChannel,
+        log_channel: discord.TextChannel,
+        level_up_channel: discord.TextChannel,
+    ) -> None:
+        """Sunucu kanallarını yapılandırır."""
+
+        await ctx.defer()
+        self.config["welcome_channel_id"] = welcome_channel.id
+        self.config["log_channel_id"] = log_channel.id
+        self.config["level_up_channel_id"] = level_up_channel.id
+        self._save_config()
+        await ctx.send("Kanallar kaydedildi.")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Setup(bot))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py>=2.3
 aiohttp
 asyncpg
-youtube_dl
+yt-dlp
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+discord.py>=2.3
+aiohttp
+asyncpg
+youtube_dl
+python-dotenv

--- a/run_setup.py
+++ b/run_setup.py
@@ -1,0 +1,17 @@
+import json
+from getpass import getpass
+
+def main():
+    print("=== Minecraft Discord Botu Kurulum ===")
+    token = getpass("Discord Bot Token: ")
+    prefix = input("Komut prefix (örn !): ") or "!"
+    guild_id = input("Minecraft sunucu ID (örn 1234567890): ") or ""
+    config = {"token": token, "prefix": prefix, "guild_id": guild_id}
+
+    with open("config.json", "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+
+    print("\nKurulum tamamlandı. `python bot.py` ile botu başlatabilirsiniz.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Enable slash/prefix hybrid commands and sync application commands on startup
- Ensure message listener processes commands and add responses for long-running tasks
- Document available commands in README

## Testing
- `python -m py_compile $(find . -name "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_689730fb81e483248de31f8683118ba2